### PR TITLE
Add missing "declare" statements in the declaration file

### DIFF
--- a/express-basic-auth.d.ts
+++ b/express-basic-auth.d.ts
@@ -11,9 +11,9 @@ import { Request, RequestHandler } from 'express'
  *
  * @param options The middleware's options (at least 'users' or 'authorizer' are mandatory).
  */
-function expressBasicAuth(options: expressBasicAuth.BasicAuthMiddlewareOptions): RequestHandler
+declare function expressBasicAuth(options: expressBasicAuth.BasicAuthMiddlewareOptions): RequestHandler
 
-namespace expressBasicAuth {
+declare namespace expressBasicAuth {
     /**
      * The configuration you pass to the middleware can take three forms, either:
      *  - A map of static users ({ bob: 'pa$$w0rd', ... }) ;


### PR DESCRIPTION
Hi @LionC,

I'm very sorry to have to annouce that I committed a small but compilation-breaking mistake when I've made a PR for the declaration file.

I was pretty sure to have put those declare statements at a moment (I do have tested that file :/), but they weren't in the final PR (I remember that I've made a copy and paste at a moment, maybe I've overriden something). And this morning while installing the new version, boom, `error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.`.

This is fixed now, again, I'm sorry you have to release a patch for this :)