### PR TITLE
add support for Promise-based authorizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ one of the three passed credentials.
 
 Alternatively, you can pass your own `authorizer` function, to check the credentials
 however you want. It will be called with a username and password and is expected to
-return `true` or `false` to indicate that the credentials were approved or not:
+return `true` or `false`, or a `Promise` of `true` or `false` to indicate that the
+credentials were approved or not:
 
 ```js
 app.use(basicAuth( { authorizer: myAuthorizer } ))
@@ -75,8 +76,18 @@ function myAuthorizer(username, password) {
 ```
 
 This will authorize all requests with credentials where the username begins with
-`'A'` and the password begins with `'secret'`. In an actual application you would
-likely look up some data instead ;-)
+`'A'` and the password begins with `'secret'`.
+
+Alternatively, you can use an `async` function or return a promise:
+
+```js
+app.use(basicAuth( { authorizer: myAuthorizer } ))
+
+async function myAuthorizer(username, password) {
+    const user = await database.findUser(username)
+    return user.comparePassword(password)
+}
+```
 
 ### Custom Async Authorization
 

--- a/index.js
+++ b/index.js
@@ -43,8 +43,20 @@ function buildMiddleware(options) {
 
         if(isAsync)
             return authorizer(authentication.name, authentication.pass, authorizerCallback)
-        else if(!authorizer(authentication.name, authentication.pass))
-            return unauthorized()
+        else {
+            var result = authorizer(authentication.name, authentication.pass)
+            if (result && typeof result.then === 'function') {
+                return result.then(function (isAuthorized) {
+                    authorizerCallback(undefined, isAuthorized)
+                }, function (error) {
+                    authorizerCallback(error)
+                }).catch(function (e) {
+                    console.log('e', e)
+                })
+            } else if (!result) {
+                return unauthorized()
+            }
+        }
 
         return next()
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ function buildMiddleware(options) {
         }
 
         function authorizerCallback(err, approved) {
-            assert.ifError(err)
+            if (err) {
+                return next(err)
+            }
 
             if(approved)
                 return next()


### PR DESCRIPTION
This PR does a couple of things (very happy to split of course)

1. improves support for errors occurring in synchronous and asynchronous authorizers
2. allows authorizers to return promises of true/false.