### PR TITLE
Added to Readme how to add a authorizer directly to the router instead of app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ app.use(basicAuth({
 }))
 ```
 
+### Adding to a router
+It's also possible to add `basicAuth` directly into a `router`.
+That's useful when you have the app in one file and your routes on it's individual files.
+
+```js
+const express = require('express')
+const router = express.Router()
+
+const authorizer = basicAuth({
+    authorizer: myAsyncAuthorizer,
+    authorizeAsync: true,
+})
+
+router.get('/some-route', authorizer, (req, res) => {
+    res.send('Birds home page')
+})
+```
+
 ## Try it
 
 The repository contains an `example.js` that you can run to play around and try


### PR DESCRIPTION
We had to use the basic auth on one of our routers today and we figured out in the code that it is possible to add to only one router instead of the whole app. 
And it was very useful in our case because we have our express app created and configured in the main file and each route is implemented on its own file and only one route needs the basic auth.

I hope this README update can help in the future whoever needs this as well.