### PR TITLE
Changed '&' operator to '&&' for boolean compare

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function buildMiddleware(options) {
 
     function staticUsersAuthorizer(username, password) {
         for(var i in users)
-            if(safeCompare(username, i) & safeCompare(password, users[i]))
+            if(safeCompare(username, i) && safeCompare(password, users[i]))
                 return true
 
         return false

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function safeCompare(userInput, secret) {
     const secretBuffer = Buffer.alloc(userInputLength, 0, 'utf8')
     secretBuffer.write(secret)
 
-    return !!(timingSafeEqual(userInputBuffer, secretBuffer) & userInputLength === secretLength)
+    return !!(timingSafeEqual(userInputBuffer, secretBuffer) && userInputLength === secretLength)
 }
 
 function ensureFunction(option, defaultValue) {


### PR DESCRIPTION
If this is intended - though I can't see why - there should be a comment explicitly mentioning it.